### PR TITLE
fix axes spacing, and display validator upon invalid kwarg

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ mpf.plot(iday,type='candle')
 
 
 ---
-In the plot below, we see **what would happend if ` no_xgaps ` did NOT** default to `True` for intraday data involving two or more days.
+In the plot below, we see **what would happen if ` no_xgaps ` did NOT** default to `True` for intraday data involving two or more days.
 
 
 ```python
@@ -553,6 +553,6 @@ With this new ` mplfinance ` package installed, in addition to the new API, user
 where `<method>` indicates the method you want to import, for example:
 
 ```python
-    from mplfinance.original_flavor import candlestick_ohlc\
+    from mplfinance.original_flavor import candlestick_ohlc
 ```
 

--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -207,14 +207,13 @@ def plot( data, **kwargs ):
     if config['volume']:
         if volumes is None:
             raise ValueError('Request for volume, but NO volume data.')
-        ax1 = fig.add_axes( [0.05, 0.25, 0.9, 0.7] )
-        ax2 = fig.add_axes( [0.05, 0.05, 0.9, 0.2], sharex=ax1 )
+        ax1 = fig.add_axes( [0.15, 0.38, 0.70, 0.50] )
+        ax2 = fig.add_axes( [0.15, 0.18, 0.70, 0.20], sharex=ax1 )
     else:
-        ax1 = fig.add_axes( [0.05, 0.05, 0.9, 0.9] )
+        ax1 = fig.add_axes( [0.15, 0.18, 0.70, 0.70] )
         ax2 = None
 
     avg_days_between_points = (dates[-1] - dates[0]) / float(len(dates))
-
 
     # Default logic for 'no_xgaps':  True for intraday data spanning 2 or more days, else False
     # Caller provided 'no_xgaps' kwarg OVERRIDES default logic.

--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -127,7 +127,7 @@ def _valid_kwargs_table():
         'figscale'      : { 'Default'   : 0.75, # scale base figure size (11" x 8.5") up or down.
                                           
                           'Implemented' : True,
-                          'Validator'   : lambda value: isinstance(value,float) },
+                          'Validator'   : lambda value: isinstance(value,float) or isinstance(value,int) },
  
         'autofmt_xdate':{ 'Default'     : False,
  
@@ -170,7 +170,9 @@ def _process_kwargs( kwargs ):
        else:
            value = kwargs[key]
            if not vkwargs[key]['Validator'](value):
-               raise ValueError('kwarg "'+key+'" with invalid value: "'+str(value)+'"')
+               import inspect
+               v = inspect.getsource(vkwargs[key]['Validator']).strip()
+               raise ValueError('kwarg "'+key+'" with invalid value: "'+str(value)+'"\n    '+v)
        # if we are here, then kwarg is valid as far as we can tell;
        #  replace the appropriate value in config:
        config[key] = value


### PR DESCRIPTION
Everything looked fine inside jupyter notebook.  However I noticed outside of the notebook, the Axes Labels were getting clipped; so I increased the spacing in the Figure around the Axes.  I also added code to display the validator code in the case where an invalid kwarg is detected.  (Also, fixed minor typos in README).