### PR TITLE
Add Renko plots to README contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - **[Adding Your Own Technical Studies to Plots](https://github.com/matplotlib/mplfinance/blob/master/examples/addplot.ipynb)**
   - **[Saving the Plot to a File](https://github.com/matplotlib/mplfinance/blob/master/examples/savefig.ipynb)**
   - **[Customizing the Appearance of Plots](https://github.com/matplotlib/mplfinance/blob/master/examples/customization_and_styles.ipynb)**
+  - **[Renko Plots](https://github.com/matplotlib/mplfinance/blob/master/examples/renko_charts.ipynb)**
   - Technical Studies (presently in development)
   - **[Latest Release Info](https://github.com/matplotlib/mplfinance#release)**
   - **[Some Background History About This Package](https://github.com/matplotlib/mplfinance#history)**


### PR DESCRIPTION
Add Renko plots to the contents of the README and include a link to the notebook in the examples folder.