### PR TITLE
Support for setting the ylabel on secondary "addplot"

### DIFF
--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -512,6 +512,8 @@ def plot( data, **kwargs ):
                 else: 
                     ax = panels.at[panid,'axes'][0]
 
+                if (apdict["ylabel"] is not None):
+                    ax.set_ylabel(apdict["ylabel"])
 
                 aptype = apdict['type']
                 if aptype == 'scatter':
@@ -702,7 +704,10 @@ def _valid_addplot_kwargs():
                                                         all([isinstance(v,(int,float)) for v in value]) },
 
         'secondary_y' : { 'Default'     : 'auto',
-                          'Validator'   : lambda value: isinstance(value,bool) or value == 'auto' }
+                          'Validator'   : lambda value: isinstance(value,bool) or value == 'auto' },
+        
+        'ylabel'      : { 'Default'     : None,
+                          'Validator'   : lambda value: isinstance(value,str) },
     }
 
     _validate_vkwargs_dict(vkwargs)


### PR DESCRIPTION
This is hopefully a minor change which adds the ability to label the secondary "addplot" plots on the y-axis.

I didn't seem to be able to set the ylabel for the newly added "addplot" feature, so I attempted to add it myself with this pull request.

No problem if you have a better way of doing this already!