### PR TITLE
CI: make sure numpy is up-to-date

### DIFF
--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -13,6 +13,7 @@ fi
 echo "PR: branch passed in: $pr_branch"
 git fetch origin +refs/pull/${pr_branch}/merge
 git checkout FETCH_HEAD
+pip3 install --upgrade numpy
 pip3 install .
 pr_version=$(python3 -c "import mplfinance; print(mplfinance.__version__)")
 git checkout master


### PR DESCRIPTION
pip is now able to _detect_ that your installation is invalid but is not falling back to either and older version of pandas or upgrading numpy to fix it.

This manually upgrades the version of numpy that is installed so that pandas will install.