### PR TITLE
Allow pathlib.Path instances as savefig values too

### DIFF
--- a/src/mplfinance/_version.py
+++ b/src/mplfinance/_version.py
@@ -1,5 +1,5 @@
 
-version_info = (0, 12, 7, 'alpha', 12)
+version_info = (0, 12, 7, 'alpha', 13)
 
 _specifier_ = {'alpha': 'a','beta': 'b','candidate': 'rc','final': ''}
 

--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -8,6 +8,7 @@ import numpy  as np
 import copy
 import io
 import math
+import pathlib
 import warnings
 import statistics as stat
 
@@ -168,7 +169,7 @@ def _valid_plot_kwargs():
                                         'Validator'   : lambda value: isinstance(value,dict) or (isinstance(value,list) and all([isinstance(d,dict) for d in value])) },
  
         'savefig'                   : { 'Default'     : None, 
-                                        'Validator'   : lambda value: isinstance(value,dict) or isinstance(value,str) or isinstance(value, io.BytesIO) },
+                                        'Validator'   : lambda value: isinstance(value,dict) or isinstance(value,str) or isinstance(value, io.BytesIO) or isinstance(value, pathlib.Path) },
  
         'block'                     : { 'Default'     : None, 
                                         'Validator'   : lambda value: isinstance(value,bool) },


### PR DESCRIPTION
Allowing figure targets to be `pathlib.Path` instances makes integration easier with libraries already providing `Path` instances (saves unnecessary `str()` conversion calls since `Path` instances work as output too)