### PR TITLE
Removing a TODO comment in `plotting.py`

### DIFF
--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -442,11 +442,6 @@ def plot( data, **kwargs ):
     else:
         raise TypeError('style should be a `dict`; why is it not?')
 
-    # ----------------------------------------------------------------------
-    # TODO:  Add some warnings, or raise an exception, if external_axes_mode
-    #        and user is trying to figscale, figratio, or figsize.
-    # ----------------------------------------------------------------------
-
     if not external_axes_mode:
         fig = plt.figure()
         _adjust_figsize(fig,config)


### PR DESCRIPTION
Remove the comment
```
    # ----------------------------------------------------------------------
    # TODO:  Add some warnings, or raise an exception, if external_axes_mode
    #        and user is trying to figscale, figratio, or figsize.
    # ----------------------------------------------------------------------
```
Since this TODO has been done in line 408.