### PR TITLE
Removed `if (plottype not in _valid_types_all) ... ` and also `num_panels = config['num_panels']`

### DIFF
--- a/src/mplfinance/_arg_validators.py
+++ b/src/mplfinance/_arg_validators.py
@@ -93,13 +93,9 @@ def _get_valid_plot_types(plottype=None):
 
     if plottype is None:
         return _valid_types_all
-
-    if plottype not in _valid_types_all:
-        return None
     elif plottype in _alias_types:
         return _alias_types[plottype]
-    else:
-        return plottype
+    return plottype
         
 
 def _mav_validator(mav_value):

--- a/src/mplfinance/_panels.py
+++ b/src/mplfinance/_panels.py
@@ -63,7 +63,6 @@ Returns
     addplot      = config['addplot']
     volume       = config['volume']
     volume_panel = config['volume_panel']
-    num_panels   = config['num_panels']
     main_panel   = config['main_panel']
     panel_ratios = config['panel_ratios']
 

--- a/src/mplfinance/_panels.py
+++ b/src/mplfinance/_panels.py
@@ -22,16 +22,16 @@ def _build_panels( figure, config ):
     ------
     The following items are used from `config`:
 
-    num_panels   : integer (0-9) or None
+    num_panels   : integer (0-31) or None
         number of panels to create
 
     addplot      : dict or None
         value for the `addplot=` kwarg passed into `mplfinance.plot()`
 
-    volume_panel : integer (0-9) or None
+    volume_panel : integer (0-31) or None
         panel id (0-number_of_panels)
 
-    main_panel   : integer (0-9) or None
+    main_panel   : integer (0-31) or None
         panel id (0-number_of_panels)
 
     panel_ratios : sequence or None
@@ -63,11 +63,12 @@ Returns
     addplot      = config['addplot']
     volume       = config['volume']
     volume_panel = config['volume_panel']
+    num_panels   = config['num_panels']
     main_panel   = config['main_panel']
     panel_ratios = config['panel_ratios']
 
     if not _valid_panel_id(main_panel):
-        raise ValueError('main_panel id must be integer 0 to 9, but is '+str(main_panel))
+        raise ValueError('main_panel id must be integer 0 to 31, but is '+str(main_panel))
 
     if num_panels is None:  # then infer the number of panels:
         pset = {0} # start with a set including only panel zero
@@ -84,12 +85,12 @@ Returns
                 if panel in backwards_panel_compatibility:
                     panel = backwards_panel_compatibility[panel]
                 if not _valid_panel_id(panel):
-                    raise ValueError('addplot panel must be integer 0 to 9, but is "'+str(panel)+'"')
+                    raise ValueError('addplot panel must be integer 0 to 31, but is "'+str(panel)+'"')
                 pset.add(panel)
 
         if volume is True:
             if not _valid_panel_id(volume_panel):
-                raise ValueError('volume_panel must be integer 0 to 9, but is "'+str(volume_panel)+'"')
+                raise ValueError('volume_panel must be integer 0 to 31, but is "'+str(volume_panel)+'"')
             pset.add(volume_panel)
 
         pset.add(main_panel)

--- a/src/mplfinance/_version.py
+++ b/src/mplfinance/_version.py
@@ -1,5 +1,5 @@
 
-version_info = (0, 12, 8, 'beta', 9)
+version_info = (0, 12, 8, 'beta', 10)
 
 _specifier_ = {'alpha': 'a','beta': 'b','candidate': 'rc','final': ''}
 

--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -866,7 +866,7 @@ def plot( data, **kwargs ):
         if config['closefig']: # True or 'auto'
             plt.close(fig)
     elif not config['returnfig']:
-        fig.show() # https://stackoverflow.com/a/13361748/1639359 
+        plt.show(block=config['block']) # https://stackoverflow.com/a/13361748/1639359
         if config['closefig'] == True or (config['block'] and config['closefig']):
             plt.close(fig)
     

--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -855,18 +855,18 @@ def plot( data, **kwargs ):
         save = config['savefig']
         if isinstance(save,dict):
             if config['tight_layout'] and 'bbox_inches' not in save:
-                plt.savefig(**save,bbox_inches='tight')
+                fig.savefig(**save,bbox_inches='tight')
             else:
-                plt.savefig(**save)
+                fig.savefig(**save)
         else:
             if config['tight_layout']:
-                plt.savefig(save,bbox_inches='tight')
+                fig.savefig(save,bbox_inches='tight')
             else:
-                plt.savefig(save)
+                fig.savefig(save)
         if config['closefig']: # True or 'auto'
             plt.close(fig)
     elif not config['returnfig']:
-        plt.show(block=config['block']) # https://stackoverflow.com/a/13361748/1639359 
+        fig.show() # https://stackoverflow.com/a/13361748/1639359 
         if config['closefig'] == True or (config['block'] and config['closefig']):
             plt.close(fig)
     


### PR DESCRIPTION
1) This is unnecessary because the kwarg validator already check whether `kwarg['type']` is in `_valid_types_all`. So if the value passed the validator then it must be in `_valid_types_all`. So we don't need to check again in function `_get_valid_plot_types` (unless...this function is used also by function other than `plot` in `plotting.py`)

2) The `num_panels = config['num_panels']` was written twice in line 62 and line 66.