### PR TITLE
 Added multi fill_between

### DIFF
--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -707,18 +707,28 @@ def plot( data, **kwargs ):
     if config['fill_between'] is not None and not external_axes_mode:
         fb    = config['fill_between']
         panid = config['main_panel']
-        if isinstance(fb,dict):
-            if 'x' in fb:
-                raise ValueError('fill_between dict may not contain `x`')
-            if 'panel' in fb:
-                panid = fb['panel']
-                del fb['panel']
+        if isinstance(fb,list):
+            for element in fb:
+                if 'panel' in element:
+                    panind = element['panel']
+                    del element['panel']
+
+                element['x'] = xdates
+                ax = panels.at[panid,'axes'][0]
+                ax.fill_between(**element)
         else:
-            fb = dict(y1=fb)
-        fb['x'] = xdates
-        ax = panels.at[panid,'axes'][0]
-        ax.fill_between(**fb)
-            
+            if isinstance(fb,dict):
+                if 'x' in fb:
+                    raise ValueError('fill_between dict may not contain `x`')
+                if 'panel' in fb:
+                    panid = fb['panel']
+                    del fb['panel']
+            else:
+                fb = dict(y1=fb)
+            fb['x'] = xdates
+            ax = panels.at[panid,'axes'][0]
+            ax.fill_between(**fb)
+ 
     # put the primary axis on one side,
     # and the twinx() on the "other" side:
     if not external_axes_mode:

--- a/src/mplfinance/plotting.py
+++ b/src/mplfinance/plotting.py
@@ -304,9 +304,10 @@ def _valid_plot_kwargs():
                                         'Description' : 'fill between specification as y-value, or sequence of'+
                                                         ' y-values, or dict containing key "y1" plus any additional'+
                                                         ' kwargs for `fill_between()`',
-                                        'Validator'   : lambda value: _num_or_seq_of_num(value) or 
+                                        'Validator'   : lambda value: _num_or_seq_of_num(value) or
                                                                      (isinstance(value,dict) and 'y1' in value and
-                                                                       _num_or_seq_of_num(value['y1'])) },
+                                                                       _num_or_seq_of_num(value['y1']))  or
+                                                                        isinstance(value,(list,tuple))},
 
         'tight_layout'              : { 'Default'     : False,
                                         'Description' : 'True|False implement tight layout (minimal padding around Figure)'+


### PR DESCRIPTION
Currently only one fill_between graph can be added to the plot.
This patch aims to add the possibility of having an array of possible
fill_between.

Example:
Currently the fill_between is as:
args = {}
args["fill_between"] = dict(y1=df[High],y2=df[Low],color=red...)
fig, axes = mpf.plot(.....,**args)

This patch also add the possibility of:
args = {}
args["fill_between"] = [
  dict(y1=df1[High],y2=df1[Low],color=red...),
  dict(y1=df2[High],y2=df2[Low],color=green...)
]