### PR TITLE
Fix a few deprecation warnings

### DIFF
--- a/src/mplfinance/_kwarg_help.py
+++ b/src/mplfinance/_kwarg_help.py
@@ -139,7 +139,7 @@ def kwarg_help( func_name=None, kwarg_names=None, sort=False ):
     dfd.columns = df.columns
     dfd.index = pd.Index(['---'])
 
-    df = dfd.append(df)
+    df = pd.concat([dfd,df])
 
     formatters = { 'Kwarg'       : make_left_formatter( klen ),
                    'Default'     : make_left_formatter( dlen ),

--- a/src/mplfinance/_styles.py
+++ b/src/mplfinance/_styles.py
@@ -20,7 +20,14 @@ def _apply_mpfstyle(style):
 
     plt.style.use('default')
 
-    if style['base_mpl_style'] is not None:
+    if style['base_mpl_style'] == 'seaborn-darkgrid':
+        # deal with deprecation of old seaborn-darkgrid:
+        try:
+            plt.style.use('seaborn-v0_8-darkgrid')
+            style['base_mpl_style'] = 'seaborn-v0_8-darkgrid'
+        except:
+            plt.style.use(style['base_mpl_style']) 
+    elif style['base_mpl_style'] is not None:
         plt.style.use(style['base_mpl_style']) 
 
     if style['rc'] is not None:

--- a/src/mplfinance/_utils.py
+++ b/src/mplfinance/_utils.py
@@ -936,7 +936,7 @@ def _construct_renko_collections(dates, highs, lows, volumes, config_renko_param
 
 
 def _construct_pointnfig_collections(dates, highs, lows, volumes, config_pointnfig_params, closes, marketcolors=None):
-    """Represent the price change with Xs and Os
+    r"""Represent the price change with Xs and Os
 
     NOTE: this code assumes if any value open, low, high, close is
     missing they all are missing

--- a/src/mplfinance/_version.py
+++ b/src/mplfinance/_version.py
@@ -1,4 +1,4 @@
-version_info = (0, 12, 9, 'beta', 5)
+version_info = (0, 12, 9, 'beta', 6)
 
 _specifier_ = {'alpha': 'a','beta': 'b','candidate': 'rc','final': ''}
 

--- a/tests/test_addplot.py
+++ b/tests/test_addplot.py
@@ -70,7 +70,7 @@ def percentB_aboveone(percentB,price):
     import numpy as np
     signal   = []
     previous = 2
-    for date,value in percentB.iteritems():
+    for date,value in percentB.items():
         if value > 1 and previous <= 1:
             signal.append(price[date]*1.01)
         else:
@@ -82,7 +82,7 @@ def percentB_belowzero(percentB,price):
     import numpy as np
     signal   = []
     previous = -1.0
-    for date,value in percentB.iteritems():
+    for date,value in percentB.items():
         if value < 0 and previous >= 0:
             signal.append(price[date]*0.99)
         else:


### PR DESCRIPTION
1. `MatplotlibDeprecationWarning: The seaborn styles shipped by Matplotlib are deprecated since 3.6, as they no longer correspond to the styles shipped by seaborn. However, they will remain available as 'seaborn-v0_8-<style>'. Alternatively, directly use the seaborn API instead.`
    - try style `'seaborn-v0_8-darkgrid'`, if exception then use old `'seaborn-darkgrid'`
    
2. `FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.`
    - use `concat()` instead of `append()`
    
3. `FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead. for date,value in percentB.iteritems():`
    - use `items()` instead of `iteritems()`
    
4. `<string> DeprecationWarning: invalid escape sequence \`
    - use **raw** string for docstring that contains an un-escaped \\
    