### PR TITLE
Decreased minimum `mav` value from 2 to 1

### DIFF
--- a/src/mplfinance/_arg_validators.py
+++ b/src/mplfinance/_arg_validators.py
@@ -141,10 +141,10 @@ def _mav_validator(mav_value):
         if not isinstance(value,(tuple,list,int)):
             return False
         if isinstance(value,int):
-            return (value >= 2 or not is_period)
+            return (value >= 1 or not is_period)
         # Must be a tuple or list here:
         for num in value:
-            if not isinstance(num,int) or (is_period and num < 2):
+            if not isinstance(num,int) or (is_period and num < 1):
                 return False
         return True
 


### PR DESCRIPTION
Decreasing the minimum `mav` value from 2 to 1 allows users to essentially plot a line graph on top of their charts. This will work, or we could create a separate parameter that plots a line graph on top of the chart. I think this is easier.