### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/workflows/mplfinance_checks.yml
+++ b/.github/workflows/mplfinance_checks.yml
@@ -1,4 +1,6 @@
 name: mplfinance Checks
+permissions:
+  contents: read
 on: [ workflow_dispatch, pull_request ]
 jobs:
   Regression_Tests:

--- a/.github/workflows/mplfinance_checks.yml
+++ b/.github/workflows/mplfinance_checks.yml
@@ -11,18 +11,23 @@ jobs:
         run: |
           echo "The job was automatically triggered by a ${{ github.event_name }} event."
           echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-          echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+          echo "The name of your branch is ${GITHUB_REF} and your repository is ${{ github.repository }}."
           echo "  "
-          echo "github.ref = ${{ github.ref }}"
+          echo "github.ref = ${GITHUB_REF}"
           echo "github.sha = ${{ github.sha }}"
-          echo "github.event.pull_request.head.ref = ${{ github.event.pull_request.head.ref }}"
+          echo "github.event.pull_request.head.ref = ${GITHUB_EVENT_PULL_REQUEST_HEAD_REF}"
           echo "github.event.pull_request.head.sha = ${{ github.event.pull_request.head.sha }}"
-          echo "github.event.pull_request.base.ref = ${{ github.event.pull_request.base.ref }}"
+          echo "github.event.pull_request.base.ref = ${GITHUB_EVENT_PULL_REQUEST_BASE_REF}"
           echo "github.event.pull_request.base.sha = ${{ github.event.pull_request.base.sha }}"
           echo "  "
+        env:
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
 
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
 
@@ -43,7 +48,9 @@ jobs:
       - name: Run Pytest
         run: python -m pytest
 
-      - run: echo "This job's status is ${{ job.status }}."
+      - run: echo "This job's status is ${JOB_STATUS}."
+        env:
+          JOB_STATUS: ${{ job.status }}
 
   Pull_Request_Updates_Version:
     runs-on: ubuntu-20.04
@@ -51,6 +58,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/pubPyPI.yml
+++ b/.github/workflows/pubPyPI.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
       with:
-        ref:  ${{ github.event.inputs.tag }}
+        ref: ${{ github.event.inputs.tag }}
+        persist-credentials: false
 
     - name: Display Coded Version 
       #run: git show ${{ github.sha }}:src/mplfinance/_version.py

--- a/.github/workflows/pubPyPI.yml
+++ b/.github/workflows/pubPyPI.yml
@@ -1,4 +1,6 @@
 name: Upload Mplfinance to PyPI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -10,6 +12,10 @@ on:
 
 jobs:
   build_and_deploy:
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -18,7 +24,7 @@ jobs:
         ref: ${{ github.event.inputs.tag }}
         persist-credentials: false
 
-    - name: Display Coded Version 
+    - name: Display Coded Version
       #run: git show ${{ github.sha }}:src/mplfinance/_version.py
       run: egrep 'version_info .*=' src/mplfinance/_version.py
 
@@ -32,7 +38,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
 
-    - name: Build 
+    - name: Build
       run: |
         python setup.py sdist bdist_wheel
         ls -l dist/*

--- a/.github/workflows/pubTestPyPI.yml
+++ b/.github/workflows/pubTestPyPI.yml
@@ -1,4 +1,6 @@
 name: Upload Mplfinance to TestPyPI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -12,13 +14,17 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     - name: Checkout Repository
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.tag }}
         persist-credentials: false
 
-    - name: Display Coded Version 
+    - name: Display Coded Version
       #run: git show ${{ github.sha }}:src/mplfinance/_version.py
       run: egrep 'version_info .*=' src/mplfinance/_version.py
 
@@ -32,7 +38,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
 
-    - name: Build 
+    - name: Build
       run: |
         python setup.py sdist bdist_wheel
         ls -l dist/*

--- a/.github/workflows/pubTestPyPI.yml
+++ b/.github/workflows/pubTestPyPI.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
       with:
-        ref:  ${{ github.event.inputs.tag }}
+        ref: ${{ github.event.inputs.tag }}
+        persist-credentials: false
 
     - name: Display Coded Version 
       #run: git show ${{ github.sha }}:src/mplfinance/_version.py


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
